### PR TITLE
Fix enum name, breaks compilation with libav9

### DIFF
--- a/channels/xrdpvr/xrdpvr_player.c
+++ b/channels/xrdpvr/xrdpvr_player.c
@@ -316,7 +316,7 @@ get_audio_config(void *vp, int *samp_per_sec, int *num_channels, int *bits_per_s
 	switch (psi->audio_codec_ctx->sample_fmt)
 	{
 		//case AV_SAMPLE_FMT_U8:
-		case SAMPLE_FMT_U8:
+		case AV_SAMPLE_FMT_U8:
 			*bits_per_samp = 8;
 			break;
 


### PR DESCRIPTION
Hi Jay,
when compiling neutrinordp on Ubuntu 14.04 I needed to fix the enum.

Cheers,
Moritz
