### PR TITLE
Ported ffmpeg API fixes from FreeRDP

### DIFF
--- a/channels/drdynvc/tsmf/ffmpeg/tsmf_ffmpeg.c
+++ b/channels/drdynvc/tsmf/ffmpeg/tsmf_ffmpeg.c
@@ -242,6 +242,9 @@ static tbool tsmf_ffmpeg_set_format(ITSMFDecoder* decoder, TS_AM_MEDIA_TYPE* med
 		case TSMF_SUB_TYPE_AC3:
 			mdecoder->codec_id = CODEC_ID_AC3;
 			break;
+		case TSMF_SUB_TYPE_MPEG4:
+			mdecoder->codec_id = CODEC_ID_MPEG4;
+			break;
 		default:
 			return false;
 	}


### PR DESCRIPTION
Many depreciated functions have been removed starting from ffmpeg versions 0.9 onwards which stop neutrino from building, ported fixes from FreeRDP [bug 285](https://github.com/FreeRDP/FreeRDP/issues/285)
