### PR TITLE
fix crash neutrinordp missing home env

### DIFF
--- a/libfreerdp-utils/file.c
+++ b/libfreerdp-utils/file.c
@@ -83,6 +83,16 @@ char* freerdp_get_home_path(rdpSettings* settings)
 	if (settings->home_path == NULL)
 		settings->home_path = getenv(HOME_ENV_VARIABLE);
 
+	/* https://github.com/neutrinolabs/xrdp/issues/719 */
+	/* workaround if home_path still is null */
+	/* happens for exmaple if in /lib/systemd/system/xrdp.service the User line is missing: */
+	/* [Service] */
+	/* ... */
+	/* User=root */
+	/* Backport of fix from FreeRDP (Pawel Jakub Dawidek) */
+	if (settings->home_path == NULL)
+		settings->home_path = xstrdup("/");
+	
 	return settings->home_path;
 }
 


### PR DESCRIPTION
https://github.com/neutrinolabs/xrdp/issues/719

One possible way to fix the crash is to add a fallback path if no home env exists.

Question is: is / a good path for it or could it cause any harm?
Would be /tmp a better path as fallback?