### PR TITLE
libfreerdp-core: tls: negotiate TLS protocol version. 

### DIFF
--- a/libfreerdp-core/tls.c
+++ b/libfreerdp-core/tls.c
@@ -35,7 +35,7 @@ tbool tls_connect(rdpTls* tls)
 	int connection_status;
 
 	LLOGLN(10, ("tls_connect:"));
-	tls->ctx = SSL_CTX_new(TLSv1_client_method());
+	tls->ctx = SSL_CTX_new(SSLv23_client_method());
 
 	if (tls->ctx == NULL)
 	{
@@ -52,6 +52,9 @@ tbool tls_connect(rdpTls* tls)
 	 * won't recognize it and will disconnect you after sending a TLS alert.
 	 */
 	SSL_CTX_set_options(tls->ctx, SSL_OP_ALL);
+	
+	// Explicitly disable deprecated SSL protocols
+	SSL_CTX_set_options(tls->ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 
 	tls->ssl = SSL_new(tls->ctx);
 


### PR DESCRIPTION
explicitly disallow SSLv2/v3 to be used since theyr'e deprecated.

TLSv1.2 is the de-facto standard which is widely used those days, so we need to be able to support it.
This change will also allow TLSv1.1, and might allow newer protocols like TLSv1.3 at the future, when they will be added to OpenSSL.
ref: https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_new.html