### PR TITLE
Implement support for gcc 5.x inline semantics

### DIFF
--- a/libfreerdp-codec/color.c
+++ b/libfreerdp-codec/color.c
@@ -86,7 +86,7 @@ void freerdp_set_pixel(uint8* data, int x, int y, int width, int height, int bpp
 	}
 }
 
-INLINE void freerdp_color_split_rgb(uint32* color, int bpp, uint8* red, uint8* green, uint8* blue, uint8* alpha, HCLRCONV clrconv)
+static INLINE void freerdp_color_split_rgb(uint32* color, int bpp, uint8* red, uint8* green, uint8* blue, uint8* alpha, HCLRCONV clrconv)
 {
 	*red = *green = *blue = 0;
 	*alpha = (clrconv->alpha) ? 0xFF : 0x00;
@@ -137,7 +137,7 @@ INLINE void freerdp_color_split_rgb(uint32* color, int bpp, uint8* red, uint8* g
 	}
 }
 
-INLINE void freerdp_color_split_bgr(uint32* color, int bpp, uint8* red, uint8* green, uint8* blue, uint8* alpha, HCLRCONV clrconv)
+static INLINE void freerdp_color_split_bgr(uint32* color, int bpp, uint8* red, uint8* green, uint8* blue, uint8* alpha, HCLRCONV clrconv)
 {
 	*red = *green = *blue = 0;
 	*alpha = (clrconv->alpha) ? 0xFF : 0x00;
@@ -188,7 +188,7 @@ INLINE void freerdp_color_split_bgr(uint32* color, int bpp, uint8* red, uint8* g
 	}
 }
 
-INLINE void freerdp_color_make_rgb(uint32* color, int bpp, uint8* red, uint8* green, uint8* blue, uint8* alpha, HCLRCONV clrconv)
+static INLINE void freerdp_color_make_rgb(uint32* color, int bpp, uint8* red, uint8* green, uint8* blue, uint8* alpha, HCLRCONV clrconv)
 {
 	switch (bpp)
 	{
@@ -229,7 +229,7 @@ INLINE void freerdp_color_make_rgb(uint32* color, int bpp, uint8* red, uint8* gr
 	}
 }
 
-INLINE void freerdp_color_make_bgr(uint32* color, int bpp, uint8* red, uint8* green, uint8* blue, uint8* alpha, HCLRCONV clrconv)
+static INLINE void freerdp_color_make_bgr(uint32* color, int bpp, uint8* red, uint8* green, uint8* blue, uint8* alpha, HCLRCONV clrconv)
 {
 	switch (bpp)
 	{

--- a/libfreerdp-core/fastpath.c
+++ b/libfreerdp-core/fastpath.c
@@ -91,7 +91,7 @@ uint16 fastpath_read_header(rdpFastPath* fastpath, STREAM* s)
 	return length;
 }
 
-INLINE void fastpath_read_update_header(STREAM* s, uint8* updateCode, uint8* fragmentation, uint8* compression)
+static INLINE void fastpath_read_update_header(STREAM* s, uint8* updateCode, uint8* fragmentation, uint8* compression)
 {
 	uint8 updateHeader;
 
@@ -101,7 +101,7 @@ INLINE void fastpath_read_update_header(STREAM* s, uint8* updateCode, uint8* fra
 	*compression = (updateHeader >> 6) & 0x03;
 }
 
-INLINE void fastpath_write_update_header(STREAM* s, uint8 updateCode, uint8 fragmentation, uint8 compression)
+static INLINE void fastpath_write_update_header(STREAM* s, uint8 updateCode, uint8 fragmentation, uint8 compression)
 {
 	uint8 updateHeader = 0;
 

--- a/libfreerdp-core/orders.c
+++ b/libfreerdp-core/orders.c
@@ -144,7 +144,7 @@ static const uint8 BMF_BPP[] =
 		0, 1, 0, 8, 16, 24, 32
 };
 
-INLINE void update_read_coord(STREAM* s, sint32* coord, tbool delta)
+static INLINE void update_read_coord(STREAM* s, sint32* coord, tbool delta)
 {
 	sint8 lsi8;
 	sint16 lsi16;
@@ -161,7 +161,7 @@ INLINE void update_read_coord(STREAM* s, sint32* coord, tbool delta)
 	}
 }
 
-INLINE void update_read_color(STREAM* s, uint32* color)
+static INLINE void update_read_color(STREAM* s, uint32* color)
 {
 	uint8 byte;
 
@@ -173,7 +173,7 @@ INLINE void update_read_color(STREAM* s, uint32* color)
 	*color |= (byte << 16);
 }
 
-INLINE void update_read_colorref(STREAM* s, uint32* color)
+static INLINE void update_read_colorref(STREAM* s, uint32* color)
 {
 	uint8 byte;
 
@@ -186,7 +186,7 @@ INLINE void update_read_colorref(STREAM* s, uint32* color)
 	stream_seek_uint8(s);
 }
 
-INLINE void update_read_color_quad(STREAM* s, uint32* color)
+static INLINE void update_read_color_quad(STREAM* s, uint32* color)
 {
 	uint8 byte;
 
@@ -199,7 +199,7 @@ INLINE void update_read_color_quad(STREAM* s, uint32* color)
 	stream_seek_uint8(s);
 }
 
-INLINE void update_read_2byte_unsigned(STREAM* s, uint32* value)
+static INLINE void update_read_2byte_unsigned(STREAM* s, uint32* value)
 {
 	uint8 byte;
 
@@ -217,7 +217,7 @@ INLINE void update_read_2byte_unsigned(STREAM* s, uint32* value)
 	}
 }
 
-INLINE void update_read_2byte_signed(STREAM* s, sint32* value)
+static INLINE void update_read_2byte_signed(STREAM* s, sint32* value)
 {
 	uint8 byte;
 	tbool negative;
@@ -238,7 +238,7 @@ INLINE void update_read_2byte_signed(STREAM* s, sint32* value)
 		*value *= -1;
 }
 
-INLINE void update_read_4byte_unsigned(STREAM* s, uint32* value)
+static INLINE void update_read_4byte_unsigned(STREAM* s, uint32* value)
 {
 	uint8 byte;
 	uint8 count;
@@ -282,7 +282,7 @@ INLINE void update_read_4byte_unsigned(STREAM* s, uint32* value)
 	}
 }
 
-INLINE void update_read_delta(STREAM* s, sint32* value)
+static INLINE void update_read_delta(STREAM* s, sint32* value)
 {
 	uint8 byte;
 
@@ -300,7 +300,7 @@ INLINE void update_read_delta(STREAM* s, sint32* value)
 	}
 }
 
-INLINE void update_read_glyph_delta(STREAM* s, uint16* value)
+static INLINE void update_read_glyph_delta(STREAM* s, uint16* value)
 {
 	uint8 byte;
 
@@ -312,7 +312,7 @@ INLINE void update_read_glyph_delta(STREAM* s, uint16* value)
 		*value = (byte & 0x3F);
 }
 
-INLINE void update_seek_glyph_delta(STREAM* s)
+static INLINE void update_seek_glyph_delta(STREAM* s)
 {
 	uint8 byte;
 
@@ -322,7 +322,7 @@ INLINE void update_seek_glyph_delta(STREAM* s)
 		stream_seek_uint8(s);
 }
 
-INLINE void update_read_brush(STREAM* s, rdpBrush* brush, uint8 fieldFlags)
+static INLINE void update_read_brush(STREAM* s, rdpBrush* brush, uint8 fieldFlags)
 {
 	if (fieldFlags & ORDER_FIELD_01)
 		stream_read_uint8(s, brush->x);
@@ -360,7 +360,7 @@ INLINE void update_read_brush(STREAM* s, rdpBrush* brush, uint8 fieldFlags)
 	}
 }
 
-INLINE void update_read_delta_rects(STREAM* s, DELTA_RECT* rectangles, int number)
+static INLINE void update_read_delta_rects(STREAM* s, DELTA_RECT* rectangles, int number)
 {
 	int i;
 	uint8 flags = 0;
@@ -405,7 +405,7 @@ INLINE void update_read_delta_rects(STREAM* s, DELTA_RECT* rectangles, int numbe
 	}
 }
 
-INLINE void update_read_delta_points(STREAM* s, DELTA_POINT* points, int number, sint16 x, sint16 y)
+static INLINE void update_read_delta_points(STREAM* s, DELTA_POINT* points, int number, sint16 x, sint16 y)
 {
 	int i;
 	uint8 flags = 0;

--- a/libfreerdp-gdi/16bpp.c
+++ b/libfreerdp-gdi/16bpp.c
@@ -791,96 +791,96 @@ int PatBlt_16bpp(HGDI_DC hdc, int nXLeft, int nYLeft, int nWidth, int nHeight, i
 	return 1;
 }
 
-INLINE void SetPixel_BLACK_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_BLACK_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = 0 */
 	*pixel = 0;
 }
 
-INLINE void SetPixel_NOTMERGEPEN_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_NOTMERGEPEN_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = ~(D | P) */
 	*pixel = ~(*pixel | *pen);
 }
 
-INLINE void SetPixel_MASKNOTPEN_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_MASKNOTPEN_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = D & ~P */
 	*pixel &= ~(*pen);
 }
 
-INLINE void SetPixel_NOTCOPYPEN_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_NOTCOPYPEN_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = ~P */
 	*pixel = ~(*pen);
 }
 
-INLINE void SetPixel_MASKPENNOT_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_MASKPENNOT_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = P & ~D */
 	*pixel = *pen & ~*pixel;
 }
 
-INLINE void SetPixel_NOT_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_NOT_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = ~D */
 	*pixel = ~(*pixel);
 }
 
-INLINE void SetPixel_XORPEN_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_XORPEN_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = D ^ P */
 	*pixel = *pixel ^ *pen;
 }
 
-INLINE void SetPixel_NOTMASKPEN_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_NOTMASKPEN_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = ~(D & P) */
 	*pixel = ~(*pixel & *pen);
 }
 
-INLINE void SetPixel_MASKPEN_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_MASKPEN_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = D & P */
 	*pixel &= *pen;
 }
 
-INLINE void SetPixel_NOTXORPEN_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_NOTXORPEN_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = ~(D ^ P) */
 	*pixel = ~(*pixel ^ *pen);
 }
 
-INLINE void SetPixel_NOP_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_NOP_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = D */
 }
 
-INLINE void SetPixel_MERGENOTPEN_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_MERGENOTPEN_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = D | ~P */
 	*pixel |= ~(*pen);
 }
 
-INLINE void SetPixel_COPYPEN_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_COPYPEN_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = P */
 	*pixel = *pen;
 }
 
-INLINE void SetPixel_MERGEPENNOT_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_MERGEPENNOT_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = P | ~D */
 	*pixel = *pen | ~(*pixel);
 }
 
-INLINE void SetPixel_MERGEPEN_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_MERGEPEN_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = P | D */
 	*pixel |= *pen;
 }
 
-INLINE void SetPixel_WHITE_16bpp(uint16 *pixel, uint16 *pen)
+static INLINE void SetPixel_WHITE_16bpp(uint16 *pixel, uint16 *pen)
 {
 	/* D = 1 */
 	*pixel = 0xFFFF;

--- a/libfreerdp-gdi/32bpp.c
+++ b/libfreerdp-gdi/32bpp.c
@@ -820,96 +820,96 @@ int PatBlt_32bpp(HGDI_DC hdc, int nXLeft, int nYLeft, int nWidth, int nHeight, i
 	return 1;
 }
 
-INLINE void SetPixel_BLACK_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_BLACK_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = 0 */
 	*pixel = 0;
 }
 
-INLINE void SetPixel_NOTMERGEPEN_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_NOTMERGEPEN_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = ~(D | P) */
 	*pixel = ~(*pixel | *pen);
 }
 
-INLINE void SetPixel_MASKNOTPEN_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_MASKNOTPEN_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = D & ~P */
 	*pixel &= ~(*pen);
 }
 
-INLINE void SetPixel_NOTCOPYPEN_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_NOTCOPYPEN_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = ~P */
 	*pixel = ~(*pen);
 }
 
-INLINE void SetPixel_MASKPENNOT_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_MASKPENNOT_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = P & ~D */
 	*pixel = *pen & ~*pixel;
 }
 
-INLINE void SetPixel_NOT_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_NOT_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = ~D */
 	*pixel = ~(*pixel);
 }
 
-INLINE void SetPixel_XORPEN_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_XORPEN_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = D ^ P */
 	*pixel = *pixel ^ *pen;
 }
 
-INLINE void SetPixel_NOTMASKPEN_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_NOTMASKPEN_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = ~(D & P) */
 	*pixel = ~(*pixel & *pen);
 }
 
-INLINE void SetPixel_MASKPEN_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_MASKPEN_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = D & P */
 	*pixel &= *pen;
 }
 
-INLINE void SetPixel_NOTXORPEN_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_NOTXORPEN_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = ~(D ^ P) */
 	*pixel = ~(*pixel ^ *pen);
 }
 
-INLINE void SetPixel_NOP_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_NOP_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = D */
 }
 
-INLINE void SetPixel_MERGENOTPEN_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_MERGENOTPEN_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = D | ~P */
 	*pixel |= ~(*pen);
 }
 
-INLINE void SetPixel_COPYPEN_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_COPYPEN_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = P */
 	*pixel = *pen;
 }
 
-INLINE void SetPixel_MERGEPENNOT_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_MERGEPENNOT_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = P | ~D */
 	*pixel = *pen | ~(*pixel);
 }
 
-INLINE void SetPixel_MERGEPEN_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_MERGEPEN_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = P | D */
 	*pixel |= *pen;
 }
 
-INLINE void SetPixel_WHITE_32bpp(uint32* pixel, uint32* pen)
+static INLINE void SetPixel_WHITE_32bpp(uint32* pixel, uint32* pen)
 {
 	/* D = 1 */
 	*pixel = 0xFFFFFF;

--- a/libfreerdp-gdi/8bpp.c
+++ b/libfreerdp-gdi/8bpp.c
@@ -700,96 +700,96 @@ int PatBlt_8bpp(HGDI_DC hdc, int nXLeft, int nYLeft, int nWidth, int nHeight, in
 	return 1;
 }
 
-INLINE void SetPixel_BLACK_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_BLACK_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = 0 */
 	*pixel = 0;
 }
 
-INLINE void SetPixel_NOTMERGEPEN_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_NOTMERGEPEN_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = ~(D | P) */
 	*pixel = ~(*pixel | *pen);
 }
 
-INLINE void SetPixel_MASKNOTPEN_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_MASKNOTPEN_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = D & ~P */
 	*pixel &= ~(*pen);
 }
 
-INLINE void SetPixel_NOTCOPYPEN_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_NOTCOPYPEN_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = ~P */
 	*pixel = ~(*pen);
 }
 
-INLINE void SetPixel_MASKPENNOT_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_MASKPENNOT_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = P & ~D */
 	*pixel = *pen & ~*pixel;
 }
 
-INLINE void SetPixel_NOT_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_NOT_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = ~D */
 	*pixel = ~(*pixel);
 }
 
-INLINE void SetPixel_XORPEN_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_XORPEN_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = D ^ P */
 	*pixel = *pixel ^ *pen;
 }
 
-INLINE void SetPixel_NOTMASKPEN_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_NOTMASKPEN_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = ~(D & P) */
 	*pixel = ~(*pixel & *pen);
 }
 
-INLINE void SetPixel_MASKPEN_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_MASKPEN_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = D & P */
 	*pixel &= *pen;
 }
 
-INLINE void SetPixel_NOTXORPEN_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_NOTXORPEN_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = ~(D ^ P) */
 	*pixel = ~(*pixel ^ *pen);
 }
 
-INLINE void SetPixel_NOP_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_NOP_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = D */
 }
 
-INLINE void SetPixel_MERGENOTPEN_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_MERGENOTPEN_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = D | ~P */
 	*pixel |= ~(*pen);
 }
 
-INLINE void SetPixel_COPYPEN_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_COPYPEN_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = P */
 	*pixel = *pen;
 }
 
-INLINE void SetPixel_MERGEPENNOT_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_MERGEPENNOT_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = P | ~D */
 	*pixel = *pen | ~(*pixel);
 }
 
-INLINE void SetPixel_MERGEPEN_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_MERGEPEN_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = P | D */
 	*pixel |= *pen;
 }
 
-INLINE void SetPixel_WHITE_8bpp(uint8* pixel, uint8* pen)
+static INLINE void SetPixel_WHITE_8bpp(uint8* pixel, uint8* pen)
 {
 	/* D = 1 */
 	*pixel = 0xFF;


### PR DESCRIPTION
gcc 5 (and later) default to `-std=gnu11` rather than `-std=gnu89`. This chances the way that the `inline` keyword is [handled by default](https://gcc.gnu.org/gcc-5/porting_to.html) [gnu.org]

This PR marks inline functions which are only used in their own translation units as `static inline`. Without this, the linker is unable to link the project executables, as the affected objects are marked as needing definitions from other translation units.

The change is still compatible with gcc 4 (used by RHEL 7 at the time of writing) and has been tested with gcc 10. It is nearly identical to upstream commit FreeRDP/FreeRDP@99492506d803a0f5a761e1efe935ee42115b04ba